### PR TITLE
hot fix for special chars in channel name

### DIFF
--- a/yt_fts.py
+++ b/yt_fts.py
@@ -207,7 +207,16 @@ def get_channel_name(channel_id):
         html = res.text
         soup = BeautifulSoup(html, 'html.parser')
         script = soup.find('script', type='application/ld+json')
-        data = json.loads(script.string)
+
+        # Hot fix for channels with special characters in the name
+        try:
+            print("Trying to parse json normally")
+            data = json.loads(script.string)
+        except:
+            print("json parse failed retrying with escaped backslashes")
+            script = script.string.replace('\\', '\\\\')
+            data = json.loads(script)
+
         channel_name = data['itemListElement'][0]['item']['name']
         print(channel_name)
         return channel_name 


### PR DESCRIPTION
`json.loads()` breaks on line 210 when trying to read script tag string with a channel that has special characters in it's 
name #8. I added a try except statement to `get_channel_name` function so it attempts to parse the json of the script tag normally, then escapes all escape characters if it fails. I want to preserve these special character codes for later use in displaying the channel name and don't know what the effect of replacing all escape sequences by default will be. 
