### PR TITLE
Seach all channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Options:
 Commands:
   delete    delete [channel id]
   download  download [channel url]
-  export    export [channel id] [search text]
+  export    export [search text] [channel id]
   list      Lists channels
-  search    search [channel id] [search text]
+  search    search [search text] [channel id]
 ```
 
 ### `download`
@@ -102,21 +102,21 @@ print a url to that point in the video. The search string does not
 have to be a word for word and match is limited to 40 characters. 
 
 ```bash
-yt-fts search [channel_id] "text you want to find"
+yt-fts search "text you want to find" [channel_id]
 ```
 **Ex:**
 ```bash
-yt-fts search UC4woSp8ITBoYDmjkukhEhxg "life in the big city"
+yt-fts search "life in the big city" UC4woSp8ITBoYDmjkukhEhxg 
 ```
 output:
 ```
-Video Title: "164 - Life In The Big City - YouTube"
+The Tim Dillon Show: "164 - Life In The Big City - YouTube"
 
     Quote: "van in the driveway life in the big city"
     Time Stamp: 00:30:44.580
     Link: https://youtu.be/dqGyCTbzYmc?t=1841
 
-Video Title: "154 - The 3 AM Episode - YouTube"
+The Tim Dillon Show: "154 - The 3 AM Episode - YouTube"
 
     Quote: "Dennis would go hey life in the big city"
     Time Stamp: 00:58:53.789
@@ -131,11 +131,11 @@ which includes things like [prefix queries](https://www.sqlite.org/fts3.html#ter
 **Ex:**
 
 ```bash
-yt-fts search UC4woSp8ITBoYDmjkukhEhxg 'rea* kni* Mali*'
+yt-fts search "rea* kni* Mali*" UC4woSp8ITBoYDmjkukhEhxg 
 ```
 output:
 ```
-Video Title: "#200 - Knife Fights In Malibu | The Tim Dillon Show - YouTube"
+The Tim Dillon Show: "#200 - Knife Fights In Malibu | The Tim Dillon Show - YouTube"
 
     Quote: "real knife fight down here in Malibu I"
     Time Stamp: 00:45:39.420
@@ -146,7 +146,7 @@ Video Title: "#200 - Knife Fights In Malibu | The Tim Dillon Show - YouTube"
 Similar to `search` except it will export all of the search results to a csv 
 with the format: `Video Title,Quote,Time Stamp,Link` as it's headers
 ```bash
-yt-fts export UC4woSp8ITBoYDmjkukhEhxg "life in the big city" 
+yt-fts export "life in the big city" UC4woSp8ITBoYDmjkukhEhxg 
 ```
 
 ### `Delete` 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ entry_points = {
 
 setup(
     name='yt-fts', 
-    version='0.1.7',
+    version='0.1.8',
     description='yt-fts is a simple python script that uses yt-dlp to scrape all of a youtube channels subtitles and load them into an sqlite database that is searchable from the command line. It allows you to query a channel for specific key word or phrase and will generate time stamped youtube urls to the video containing the keyword.',
     long_description=long_description,
     long_description_content_type='text/markdown', 

--- a/yt_fts/db_scripts.py
+++ b/yt_fts/db_scripts.py
@@ -96,14 +96,24 @@ def search_channel(channel_id, text):
 def get_title_from_db(video_id):
     db = Database(db_name)
 
-    return db.execute(f"SELECT video_title FROM Videos WHERE video_id = ?", [video_id]).fetchone()
+    return db.execute(f"SELECT video_title FROM Videos WHERE video_id = ?", [video_id]).fetchone()[0]
 
 
-def get_channel_name_from_db(channel_id):
+def search_all(text):
+    db = Database(db_name)
+
+    return list(db["Subtitles"].search(text))
+
+
+def get_channel_name_from_id(channel_id):
     db = Database(db_name)
 
     return db.execute(f"SELECT channel_name FROM Channels WHERE channel_id = ?", [channel_id]).fetchone()[0]
 
+def get_channel_name_from_video_id(video_id):
+    db = Database(db_name)
+
+    return db.execute(f"SELECT channel_name FROM Channels WHERE channel_id = (SELECT channel_id FROM Videos WHERE video_id = ?)", [video_id]).fetchone()[0]
 
 def delete_channel(channel_id):
     conn = sqlite3.connect(db_name)


### PR DESCRIPTION
# #13
- Added multi channel search and export functionality via `--all` flag 
- This mixes channels together so I added [`get_channel_name_from_video_id`](https://github.com/NotJoeMartinez/yt-fts/blob/57db41222643f7c07b4347f9dee08e0244d5ae4c/yt_fts/db_scripts.py#L113) to get channel name from a video id 
- Channel names now output to console and csv to prevent confusion when running multi channel search 

### Slightly modified search and export syntax  
Search query now goes before ids or flags. The intent is to cut down on users having to retype search queries because they forgot to copy the id. 

```bash
# search specific channel
yt-fts search "text to search" [channel_id]

# search all channels 
yt-fts search "text to search" --all 
```
**Ex:**
```bash
yt-fts search "in the big city" UC4woSp8ITBoYDmjkukhEhxg 
yt-fts search "in the big city" --all
```
