### PR TITLE
Allow for searching by channel name and Rowid

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the video containing the keyword.
 
 - [Blog Post](https://notjoemartinez.com/blog/youtube_full_text_search/)
 
-### Installation 
+## Installation 
 
 **pip**
 ```bash
@@ -23,7 +23,7 @@ pip install -r requirements.txt
 python3 -m yt-fts
 ```
 
-### Dependencies 
+## Dependencies 
 This project requires [yt-dlp](https://github.com/yt-dlp/yt-dlp) installed globally. Platform specific installation instructions are available on the [yt-dlp wiki](https://github.com/yt-dlp/yt-dlp/wiki/Installation). 
 
 **pip**
@@ -91,22 +91,38 @@ yt-fts list
 output:
 ```
 Listing channels
-channel_id                channel_name         channel_url
-------------------------  -------------------  ---------------------------------------------------------------
-UC4woSp8ITBoYDmjkukhEhxg  The Tim Dillon Show  https://www.youtube.com/channel/UC4woSp8ITBoYDmjkukhEhxg/videos
+  id  channel_name         channel_url
+----  -------------------  ---------------------------------------------------------------
+   1  The Tim Dillon Show  https://www.youtube.com/channel/UC4woSp8ITBoYDmjkukhEhxg/videos
+   2  Lex Fridman          https://www.youtube.com/channel/UCSHZKyawb77ixDdsGog4iWA/videos
+   3  Traversy Media       https://www.youtube.com/channel/UC29ju8bIPH5as8OGnQzwJyA/videos
 ```
 
 ## `search`
-Search a channel for text based off the channel id you give it and 
-print a url to that point in the video. The search string does not 
-have to be a word for word and match is limited to 40 characters. 
+you can specify which channel to search in using the `id` or `channel_name` 
+and it will print a url to that point in the video. 
 
-```bash
-yt-fts search "text you want to find" [channel_id]
 ```
+Usage: yt-fts search [OPTIONS] SEARCH_TEXT [CHANNEL]
+
+  Search for a specified text within a channel or all channels. SEARCH_TEXT is
+  the text to search for. CHANNEL is the name or id of the channel to search
+  in. CHANNEL is required unless the '--all' option is specified.
+
+Options:
+  --all   Search in all channels. If not specified, a channel name or id is
+          required.
+```
+
+- The search string does not have to be a word for word and match 
+- Use Id if you have channels with the same name or channels that have special characters in their name 
+- Search strings are limited to 40 characters. 
+
 **Ex:**
 ```bash
-yt-fts search "life in the big city" UC4woSp8ITBoYDmjkukhEhxg 
+yt-fts search "life in the big city" "The Tim Dillon Show"
+# or 
+yt-fts search "life in the big city" 1  # assuming 1 is id of channel
 ```
 output:
 ```
@@ -133,7 +149,7 @@ which includes things like [prefix queries](https://www.sqlite.org/fts3.html#ter
 **Ex:**
 
 ```bash
-yt-fts search "rea* kni* Mali*" UC4woSp8ITBoYDmjkukhEhxg 
+yt-fts search "rea* kni* Mali*" "The Tim Dillon Show" 
 ```
 output:
 ```
@@ -149,7 +165,7 @@ Similar to `search` except it will export all of the search results to a csv
 with the format: `Channel Name,Video Title,Quote,Time Stamp,Link` as it's headers
 
 ```bash
-yt-fts export "life in the big city" UC4woSp8ITBoYDmjkukhEhxg 
+yt-fts export "life in the big city" "The Tim Dillon Show"
 ```
 
 You can export from all channels in your database as well

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ entry_points = {
 
 setup(
     name='yt-fts', 
-    version='0.1.9',
+    version='0.1.10',
     description='yt-fts is a simple python script that uses yt-dlp to scrape all of a youtube channels subtitles and load them into an sqlite database that is searchable from the command line. It allows you to query a channel for specific key word or phrase and will generate time stamped youtube urls to the video containing the keyword.',
     long_description=long_description,
     long_description_content_type='text/markdown', 

--- a/yt_fts/db_scripts.py
+++ b/yt_fts/db_scripts.py
@@ -150,8 +150,6 @@ def get_channel_id_from_name(channel_name):
 
     res = db.execute(f"SELECT channel_id FROM Channels WHERE channel_name = ?", [channel_name]).fetchall()
 
-    print("res: ", res)
-
     if len(res) > 1:
         channels = db.execute(f"SELECT ROWID, channel_name, channel_url FROM Channels WHERE channel_name = ?", [channel_name]).fetchall()
         print(tabulate(channels, headers=["id", "channel_name", "channel_url"]))
@@ -161,4 +159,4 @@ def get_channel_id_from_name(channel_name):
     if len(res) == 0:
         return None
     else:
-        return res[0]
+        return res[0][0]

--- a/yt_fts/db_scripts.py
+++ b/yt_fts/db_scripts.py
@@ -84,11 +84,14 @@ def add_subtitle(video_id, start_time, text):
 def get_channels():
     db = Database(db_name)
 
-    return db.execute("SELECT * FROM Channels").fetchall()
+    # return db.execute("SELECT * FROM Channels").fetchall()
+    return db.execute("SELECT ROWID, channel_name, channel_url FROM Channels").fetchall()
 
 
 def search_channel(channel_id, text):
     db = Database(db_name)
+
+    # cur = db.execute(f"SELECT video_id FROM Videos WHERE channel_id = ?", [channel_id]) 
 
     return list(db["Subtitles"].search(text, where=f"video_id IN (SELECT video_id FROM Videos WHERE channel_id = '{channel_id}')"))
 
@@ -125,3 +128,24 @@ def delete_channel(channel_id):
 
     conn.commit()
     conn.close()
+
+
+def get_channel_id_from_rowid(rowid):
+    db = Database(db_name)
+
+    res = db.execute(f"SELECT channel_id FROM Channels WHERE ROWID = ?", [rowid]).fetchone()
+
+    if res is None:
+        return None
+    else:
+        return res[0]
+
+
+def get_channel_id_from_name(channel_name):
+    db = Database(db_name)
+
+    res = db.execute(f"SELECT channel_id FROM Channels WHERE channel_name = ?", [channel_name]).fetchone()
+    if res is None:
+        return None
+    else:
+        return res[0]

--- a/yt_fts/db_scripts.py
+++ b/yt_fts/db_scripts.py
@@ -1,5 +1,9 @@
-from sqlite_utils import Database
 import sqlite3
+
+from sqlite_utils import Database
+from tabulate import tabulate
+
+from yt_fts.utils import show_message
 
 db_name = 'subtitles.db'
 
@@ -144,8 +148,17 @@ def get_channel_id_from_rowid(rowid):
 def get_channel_id_from_name(channel_name):
     db = Database(db_name)
 
-    res = db.execute(f"SELECT channel_id FROM Channels WHERE channel_name = ?", [channel_name]).fetchone()
-    if res is None:
+    res = db.execute(f"SELECT channel_id FROM Channels WHERE channel_name = ?", [channel_name]).fetchall()
+
+    print("res: ", res)
+
+    if len(res) > 1:
+        channels = db.execute(f"SELECT ROWID, channel_name, channel_url FROM Channels WHERE channel_name = ?", [channel_name]).fetchall()
+        print(tabulate(channels, headers=["id", "channel_name", "channel_url"]))
+        print("")
+        show_message("multiple_channels_found")
+        exit()
+    if len(res) == 0:
         return None
     else:
         return res[0]

--- a/yt_fts/utils.py
+++ b/yt_fts/utils.py
@@ -6,7 +6,9 @@ import re
 def show_message(code):
     error_dict = {
         "search_too_long": "Error: Search text must be less than 40 characters",
-        "no_matches_found": "No matches found.\n- Try shortening the search text or use wildcards to match partial words."
+        "no_matches_found": "No matches found.\n- Try shortening the search text or use wildcards to match partial words.",
+        "no_channels_found": "channel not found.\n- Try using channel id",
+        "multiple_channels_found": "Multiple channels found.\n- Try searching by id",
     }
 
     print(error_dict[code])

--- a/yt_fts/utils.py
+++ b/yt_fts/utils.py
@@ -7,8 +7,8 @@ def show_message(code):
     error_dict = {
         "search_too_long": "Error: Search text must be less than 40 characters",
         "no_matches_found": "No matches found.\n- Try shortening the search text or use wildcards to match partial words.",
-        "no_channels_found": "channel not found.\n- Try using channel id",
-        "multiple_channels_found": "Multiple channels found.\n- Try searching by id",
+        "channel_not_found": "channel not found.\n- Try using channel id",
+        "multiple_channels_found": "Multiple channels found.\n- Try using id",
     }
 
     print(error_dict[code])

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -83,18 +83,21 @@ def export(channel, search_text, all):
         export_search(channel_id, search_text, file_name)
 
 
-@click.command( help="delete [channel_id]")
-@click.argument("channel_id", required=True)
-def delete(channel_id):
-    channel_name = get_channel_name_from_id(channel_id) 
+@click.command( help="delete [id] or [\"channel_name\"]")
+@click.argument("channel", required=True)
+def delete(channel):
 
-    print(f"Deleting channel {channel_name}")
+    channel_id = get_channel_id_from_input(channel)
+    channel_name = get_channel_name_from_id(channel_id) 
+    channel_url = f"https://www.youtube.com/channel/{channel_id}/videos"
+
+    print(f"Deleting channel {channel_name}: {channel_url}")
     print("Are you sure you want to delete this channel and all its data?")
     confirm = input("y/n: ")
 
     if confirm == "y":
-        click.echo(f'deleting channel {channel_name}')
         delete_channel(channel_id)
+        print(f"Deleted channel {channel_name}: {channel_url}")
     else:
         print("Exiting")
 

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -15,7 +15,7 @@ def cli():
 def list():
     click.echo("Listing channels")
     channels = get_channels()
-    print(tabulate(channels, headers=["channel_id","channel_name", "channel_url"]))
+    print(tabulate(channels, headers=["id", "channel_name", "channel_url"]))
 
 
 @click.command( help='download [channel url]')
@@ -42,21 +42,31 @@ def download(channel_url, channel_id, language, number_of_jobs):
 @click.command( help='search [channel_id] [search_text]')
 @click.argument('search_text', required=True)
 @click.option('--all', is_flag=True, help='Search in all channels')
-@click.argument('channel_id', required=False)
-def search(channel_id, search_text, all):
-    if len(search_text) > 40:
-        show_message("search_too_long")
-        return
+@click.argument('channel', required=False)
+def search(channel, search_text, all):
+    name_res = get_channel_id_from_name(channel) 
+    id_res = get_channel_id_from_rowid(channel) 
+
+    if id_res is not None:
+        channel_id = id_res
+
+    if name_res is not None: 
+        channel_id = name_res
 
     if all:
         click.echo('Searching in all channels')
         get_text("all", search_text)
+
     else:
         if channel_id is None:
             click.echo('Error: Channel ID is required when not using --all option')
             return
         click.echo(f'Searching in channel {channel_id}')
         get_text(channel_id, search_text)
+
+    if len(search_text) > 40:
+        show_message("search_too_long")
+        exit()
 
 
 @click.command( help="export [channel_id] [search_text]")

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -63,11 +63,13 @@ def search(channel, search_text, all):
 @click.command( help="export [channel_id] [search_text]")
 @click.argument("search_text", required=True)
 @click.option("--all", is_flag=True, help="Export from all channels")
-@click.argument("channel_id", required=False)
-def export(channel_id, search_text, all):
+@click.argument('channel', required=False)
+def export(channel, search_text, all):
     if len(search_text) > 40:
         show_message("search_too_long")
-        return
+        exit() 
+
+    channel_id = get_channel_id_from_input(channel)
 
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
 
@@ -76,9 +78,6 @@ def export(channel_id, search_text, all):
         click.echo(f"Exporting search results from all channels to csv: {file_name}")
         export_search("all", search_text, file_name)
     else:
-        if channel_id is None:
-            click.echo("Error: Channel ID is required when not using --all option")
-            return
         file_name = f"{channel_id}_{timestamp}.csv"
         click.echo(f"Exporting search results to csv: {file_name}")
         export_search(channel_id, search_text, file_name)
@@ -97,7 +96,7 @@ def delete(channel_id):
         click.echo(f'deleting channel {channel_name}')
         delete_channel(channel_id)
     else:
-        print("Aborting")
+        print("Exiting")
 
 
 commands = [list, download, search, delete, export]

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -44,29 +44,20 @@ def download(channel_url, channel_id, language, number_of_jobs):
 @click.option('--all', is_flag=True, help='Search in all channels')
 @click.argument('channel', required=False)
 def search(channel, search_text, all):
-    name_res = get_channel_id_from_name(channel) 
-    id_res = get_channel_id_from_rowid(channel) 
-
-    if id_res is not None:
-        channel_id = id_res
-
-    if name_res is not None: 
-        channel_id = name_res
-
-    if all:
-        click.echo('Searching in all channels')
-        get_text("all", search_text)
-
-    else:
-        if channel_id is None:
-            click.echo('Error: Channel ID is required when not using --all option')
-            return
-        click.echo(f'Searching in channel {channel_id}')
-        get_text(channel_id, search_text)
 
     if len(search_text) > 40:
         show_message("search_too_long")
         exit()
+
+    channel_id = get_channel_id_from_input(channel)
+
+    if all == True:
+        click.echo('Searching in all channels')
+        get_text("all", search_text)
+    else:
+        click.echo(f'Searching in channel {channel_id}')
+        get_text(channel_id, search_text)
+
 
 
 @click.command( help="export [channel_id] [search_text]")
@@ -182,3 +173,20 @@ def export_search(channel_id, text, file_name):
             time = time_to_secs(time_stamp) 
 
             writer.writerow([channel_name,video_title, subs.strip(), time_stamp, f"https://youtu.be/{video_id}?t={time}"])
+
+
+def get_channel_id_from_input(channel_input):
+    """
+    Checks if the input is a rowid or a channel name and returns channel id
+    """
+    name_res = get_channel_id_from_name(channel_input) 
+    id_res = get_channel_id_from_rowid(channel_input) 
+
+    if id_res != None:
+        return id_res
+    elif name_res != None: 
+        return name_res
+    else:
+        show_message("channel_not_found")
+        exit()
+    

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -13,7 +13,6 @@ def cli():
 
 @click.command(help="Lists channels")
 def list():
-    click.echo("Listing channels")
     channels = get_channels()
     print(tabulate(channels, headers=["id", "channel_name", "channel_url"]))
 
@@ -39,9 +38,9 @@ def download(channel_url, channel_id, language, number_of_jobs):
         print("Error finding channel id try --channel-id option")
 
 
-@click.command( help='search [channel_id] [search_text]')
+@click.command(help="Search for a specified text within a channel or all channels. SEARCH_TEXT is the text to search for. CHANNEL is the name or id of the channel to search in. CHANNEL is required unless the '--all' option is specified.")
 @click.argument('search_text', required=True)
-@click.option('--all', is_flag=True, help='Search in all channels')
+@click.option('--all', is_flag=True, help='Search in all channels. If ied, a channel name or id is required.')
 @click.argument('channel', required=False)
 def search(channel, search_text, all):
 
@@ -49,13 +48,17 @@ def search(channel, search_text, all):
         show_message("search_too_long")
         exit()
 
-    channel_id = get_channel_id_from_input(channel)
-
     if all == True:
-        click.echo('Searching in all channels')
+        print('Searching in all channels')
         get_text("all", search_text)
+    elif channel == None:
+        print('Error: Channel name or id is required when not using --all option')
+        exit()
     else:
-        click.echo(f'Searching in channel {channel_id}')
+        channel_id = get_channel_id_from_input(channel)
+        channel_name = get_channel_name_from_id(channel_id)
+        channel_url = f"https://www.youtube.com/channel/{channel_id}/videos"
+        print(f"Searching in channel \"{channel_name}\": {channel_url}")
         get_text(channel_id, search_text)
 
 


### PR DESCRIPTION
### Overview
- search, export and delete commands can now be specified with channel name or row ID
    - `yt-fts search [SEARCH_TEXT] [NAME_OF_CHANNEL or ID]`
- Introduces bug with RowID and numerical channel name confusion  

On issue #3 it was suggested to allow channel aliasing to prevent users from having to input the whole `channel_id`. This pr somewhat implements this except the alias are already defined by SQLite Row IDs. This has the slight drawback that the ids will stop being numerical if a user deletes a channel but it's way better than having to manually copy and paste the channel id. I added the ability to search by channel name and some error checking for if they have two channels named the same. I implemented this for the commands `export` and `delete` as well.

**This technically introduces a bug** if a user has a channel with a numerical name and they manage to download enough channels up to where there is a row id with the same name as this channel it will probably result in unintended deletions or incorrect searches and exports. I'll make an issue for this after merge

