### PR TITLE
Search individual videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ saved_vtt/**
 make_dist.sh
 *.sql
 tests.sh
+tests/*.txt

--- a/README.md
+++ b/README.md
@@ -99,25 +99,26 @@ Listing channels
 ```
 
 ## `search`
-you can specify which channel to search in using the `id` or `channel_name` 
-and it will print a url to that point in the video. 
-
 ```
-Usage: yt-fts search [OPTIONS] SEARCH_TEXT [CHANNEL]
+Usage: yt-fts search [OPTIONS] SEARCH_TEXT
 
-  Search for a specified text within a channel or all channels. SEARCH_TEXT is
-  the text to search for. CHANNEL is the name or id of the channel to search
-  in. CHANNEL is required unless the '--all' option is specified.
+  Search for a specified text within a channel, a specific video, or all
+  channels. SEARCH_TEXT is the text to search for.
 
 Options:
-  --all   Search in all channels. If not specified, a channel name or id is
-          required.
+  --channel TEXT  The name or id of the channel to search in. This is required
+                  unless the --all or --video options are used.
+  --video TEXT    The id of the video to search in. This is used instead of
+                  the channel option.
+  --all           Search in all channels.
+  --help          Show this message and exit.
 ```
 
 - The search string does not have to be a word for word and match 
 - Use Id if you have channels with the same name or channels that have special characters in their name 
 - Search strings are limited to 40 characters. 
 
+### Search by channel
 **Ex:**
 ```bash
 yt-fts search "life in the big city" "The Tim Dillon Show"
@@ -139,6 +140,14 @@ Use `--all` to search all channels in your database
 **Ex:**
 ```bash
 yt-fts search "text to search" --all
+```
+
+### Search in video
+Use `--video` to search in a specific video by it's ID
+
+**Ex:**
+```bash
+yt-fts search "text to search" --video [VIDEO_ID]
 ```
 
 ### Advanced Search Syntax

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Options:
 ### Search by channel
 **Ex:**
 ```bash
-yt-fts search "life in the big city" "The Tim Dillon Show"
+yt-fts search "life in the big city" --channel "The Tim Dillon Show"
 # or 
-yt-fts search "life in the big city" 1  # assuming 1 is id of channel
+yt-fts search "life in the big city" --channel 1  # assuming 1 is id of channel
 ```
 output:
 ```
@@ -131,6 +131,7 @@ The Tim Dillon Show: "164 - Life In The Big City - YouTube"
 
     Quote: "van in the driveway life in the big city"
     Time Stamp: 00:30:44.580
+    Video ID: dqGyCTbzYmc
     Link: https://youtu.be/dqGyCTbzYmc?t=1841
 ```
 
@@ -158,7 +159,7 @@ which includes things like [prefix queries](https://www.sqlite.org/fts3.html#ter
 **Ex:**
 
 ```bash
-yt-fts search "rea* kni* Mali*" "The Tim Dillon Show" 
+yt-fts search "rea* kni* Mali*" --channel "The Tim Dillon Show" 
 ```
 output:
 ```
@@ -166,6 +167,7 @@ The Tim Dillon Show: "#200 - Knife Fights In Malibu | The Tim Dillon Show - YouT
 
     Quote: "real knife fight down here in Malibu I"
     Time Stamp: 00:45:39.420
+    Video ID: e79H5nxS65Q
     Link: https://youtu.be/e79H5nxS65Q?t=2736
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ entry_points = {
 
 setup(
     name='yt-fts', 
-    version='0.1.12',
+    version='0.1.13',
     description='yt-fts is a simple python script that uses yt-dlp to scrape all of a youtube channels subtitles and load them into an sqlite database that is searchable from the command line. It allows you to query a channel for specific key word or phrase and will generate time stamped youtube urls to the video containing the keyword.',
     long_description=long_description,
     long_description_content_type='text/markdown', 

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -65,6 +65,18 @@ test_search_export_all(){
     done
 }
 
+# search video  
+test_search_video(){
+
+    keywords=("electrion" "same origin policy" "local storage")
+
+    # loop through stack smashing keywords by name
+    for keyword in "${keywords[@]}" 
+    do
+        yt-fts search "${keyword}" --video "jkJWA_CWrQs"
+    done
+}
+
 test_errors(){
     ## search errors
     yt-fts search "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" stacksmashing 
@@ -90,6 +102,7 @@ if [[ -z "$@" ]]; then
     echo "  ./basic.sh all"
     echo "  ./basic.sh download"
     echo "  ./basic.sh search"
+    echo "  ./basic.sh video"
     echo "  ./basic.sh export"
     echo "  ./basic.sh search-export-all"
     echo "  ./basic.sh errors"
@@ -99,6 +112,8 @@ elif [[ "$@" == "download" ]]; then
     download
 elif [[ "$@" == "search" ]]; then
     test_search_by_channel
+elif [[ "$@" == "video" ]]; then
+    test_search_video
 elif [[ "$@" == "export" ]]; then
     test_export_by_channel
 elif [[ "$@" == "search-export-all" ]]; then
@@ -110,6 +125,7 @@ else
     echo "  ./basic.sh all"
     echo "  ./basic.sh download"
     echo "  ./basic.sh search"
+    echo "  ./basic.sh video"
     echo "  ./basic.sh export"
     echo "  ./basic.sh search-export-all"
     echo "  ./basic.sh errors"

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -2,6 +2,8 @@
 # downloads
 download() {
     rm *.db
+    rm *.csv
+    rm *.txt
     stack_smashing="https://www.youtube.com/@stacksmashing/videos"
     pwn_function="https://www.youtube.com/@PwnFunction/videos"
     yt-fts download --language en --number-of-jobs 5 $stack_smashing
@@ -18,16 +20,16 @@ test_search_by_channel(){
     # loop through stack smashing keywords by name
     for keyword in "${stack_smashing_keywords[@]}" 
     do
-        yt-fts search "${keyword}" stacksmashing 
-        yt-fts search "${keyword}" 1
+        yt-fts search "${keyword}" --channel stacksmashing >> search_by_channel_name.txt
+        yt-fts search "${keyword}" --channel 1 >> search_by_channel_id.txt
     done
 
     # loop through pwn function keywords
-    for keyword in "${pwn_function_keywords[@]}" 
-    do
-        yt-fts search "${keyword}" PwnFunction 
-        yt-fts search "${keyword}" 2
-    done
+    # for keyword in "${pwn_function_keywords[@]}" 
+    # do
+    #     yt-fts search "${keyword}" --channel PwnFunction >> search_by_channel_name.txt
+    #     yt-fts search "${keyword}" --channel 2
+    # done
 
 }
 
@@ -60,7 +62,7 @@ test_search_export_all(){
     # loop through stack smashing keywords by name
     for keyword in "${keywords[@]}" 
     do
-        yt-fts search "${keyword}" --all
+        yt-fts search "${keyword}" --all >> search_by_all.txt
         yt-fts export "${keyword}" --all
     done
 }
@@ -73,18 +75,18 @@ test_search_video(){
     # loop through stack smashing keywords by name
     for keyword in "${keywords[@]}" 
     do
-        yt-fts search "${keyword}" --video "jkJWA_CWrQs"
+        yt-fts search "${keyword}" --video "jkJWA_CWrQs" >> search_video.txt
     done
 }
 
 test_errors(){
     ## search errors
-    yt-fts search "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" stacksmashing 
-    yt-fts search "these words probably do not exist" stacksmashing
+    yt-fts search "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  stacksmashing 
+    yt-fts search "these words probably do not exist"  stacksmashing
     yt-fts search "linux" foobar
 
     ## export errors
-    yt-fts export  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" stacksmashing 
+    yt-fts export  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  stacksmashing 
     yt-fts export "these words probably do not exist" stacksmashing
     yt-fts export "linux" foobar
 }

--- a/yt_fts/db_utils.py
+++ b/yt_fts/db_utils.py
@@ -88,28 +88,30 @@ def add_subtitle(video_id, start_time, text):
 def get_channels():
     db = Database(db_name)
 
-    # return db.execute("SELECT * FROM Channels").fetchall()
     return db.execute("SELECT ROWID, channel_name, channel_url FROM Channels").fetchall()
 
 
 def search_channel(channel_id, text):
     db = Database(db_name)
 
-    # cur = db.execute(f"SELECT video_id FROM Videos WHERE channel_id = ?", [channel_id]) 
-
     return list(db["Subtitles"].search(text, where=f"video_id IN (SELECT video_id FROM Videos WHERE channel_id = '{channel_id}')"))
+
+
+def search_video(video_id, text):
+    db = Database(db_name)
+
+    return list(db["Subtitles"].search(text, where=f"video_id = '{video_id}'"))
+
+def search_all(text):
+    db = Database(db_name)
+
+    return list(db["Subtitles"].search(text))
 
 
 def get_title_from_db(video_id):
     db = Database(db_name)
 
     return db.execute(f"SELECT video_title FROM Videos WHERE video_id = ?", [video_id]).fetchone()[0]
-
-
-def search_all(text):
-    db = Database(db_name)
-
-    return list(db["Subtitles"].search(text))
 
 
 def get_channel_name_from_id(channel_id):

--- a/yt_fts/download_utils.py
+++ b/yt_fts/download_utils.py
@@ -4,7 +4,7 @@ from progress.bar import Bar
 from concurrent.futures import ThreadPoolExecutor
 from bs4 import BeautifulSoup
 
-from yt_fts.db_scripts import add_video
+from yt_fts.db_utils import add_video
 from yt_fts.utils import parse_vtt
 
 

--- a/yt_fts/search_utils.py
+++ b/yt_fts/search_utils.py
@@ -1,0 +1,55 @@
+from yt_fts.db_utils import * 
+from yt_fts.utils import *
+
+def get_text(channel_id, text):
+    """
+    Calls search functions and prints the results 
+    """
+    if channel_id == "all":
+        res = search_all(text)
+    else:
+        res = search_channel(channel_id, text)
+
+    if len(res) == 0:
+        show_message("no_matches_found")
+        exit()
+
+    for quote in res:
+        video_id = quote["video_id"]
+        subs = quote["text"]
+        time_stamp = quote["timestamp"]
+        video_title = get_title_from_db(video_id)
+        channel_name = get_channel_name_from_video_id(video_id)
+        time = time_to_secs(time_stamp) 
+
+        print("")
+        print(f"{channel_name}: \"{video_title}\"")
+        print(f"") 
+        print(f"    Quote: \"{subs.strip()}\"")
+        print(f"    Time Stamp: {time_stamp}")
+        print(f"    Video ID: {video_id}")
+        print(f"    Link: https://youtu.be/{video_id}?t={time}\n")
+
+
+def get_text_by_video_id(video_id, text):
+    res = search_video(video_id, text)
+    if len(res) == 0:
+        show_message("no_matches_found")
+        exit()
+    
+    for quote in res:
+        subs = quote["text"]
+        time_stamp = quote["timestamp"]
+        video_title = get_title_from_db(video_id)
+        channel_name = get_channel_name_from_video_id(video_id)
+        time = time_to_secs(time_stamp) 
+
+        print("")
+        print(f"{channel_name}: \"{video_title}\"")
+        print(f"") 
+        print(f"    Quote: \"{subs.strip()}\"")
+        print(f"    Time Stamp: {time_stamp}")
+        print(f"    Video ID: {video_id}")
+        print(f"    Link: https://youtu.be/{video_id}?t={time}\n")
+
+

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -2,8 +2,9 @@ import click, tempfile, requests, datetime, csv
 
 from tabulate import tabulate
 
-from yt_fts.db_scripts import *
-from yt_fts.download_scripts import *
+from yt_fts.search_utils import *
+from yt_fts.db_utils import *
+from yt_fts.download_utils import *
 from yt_fts.utils import *
 
 YT_FTS_VERSION = "0.1.12"
@@ -41,28 +42,32 @@ def download(channel_url, channel_id, language, number_of_jobs):
         print("Error finding channel id try --channel-id option")
 
 
-@click.command(help="Search for a specified text within a channel or all channels. SEARCH_TEXT is the text to search for. CHANNEL is the name or id of the channel to search in. CHANNEL is required unless the '--all' option is specified.")
-@click.argument('search_text', required=True)
-@click.option('--all', is_flag=True, help='Search in all channels. If ied, a channel name or id is required.')
-@click.argument('channel', required=False)
-def search(channel, search_text, all):
+@click.command(help="Search for a specified text within a channel, specific video, or all channels. SEARCH_TEXT is the text to search for.")
+@click.argument("search_text", required=True)
+@click.option("--channel", default=None, help="The name or id of the channel to search in. This is required unless the --all or --video options are used.")
+@click.option("--video", default=None, help="The id of the video to search in. This is used instead of the channel option.")
+@click.option("--all", is_flag=True, help="Search in all channels.")
+def search(search_text, channel, video, all):
 
     if len(search_text) > 40:
         show_message("search_too_long")
         exit()
 
-    if all == True:
+    if all:
         print('Searching in all channels')
         get_text("all", search_text)
-    elif channel == None:
-        print('Error: Channel name or id is required when not using --all option')
-        exit()
-    else:
+    elif video:
+        print(f"Searching in video {video}")
+        get_text_by_video_id(video, search_text)
+    elif channel:
         channel_id = get_channel_id_from_input(channel)
         channel_name = get_channel_name_from_id(channel_id)
         channel_url = f"https://www.youtube.com/channel/{channel_id}/videos"
         print(f"Searching in channel \"{channel_name}\": {channel_url}")
         get_text(channel_id, search_text)
+    else:
+        print("Error: Either --channel, --video, or --all option must be provided")
+        exit()
 
 
 @click.command( help="export [channel_id] [search_text]")
@@ -122,35 +127,6 @@ def download_channel(channel_id, channel_name, language, number_of_jobs, s):
         download_vtts(number_of_jobs, list_of_videos_urls, language, tmp_dir)
         add_channel_info(channel_id, channel_name, channel_url)
         vtt_to_db(channel_id, tmp_dir, s)
-
-
-def get_text(channel_id, text):
-    """
-    Calls search functions and prints the results 
-    """
-    if channel_id == "all":
-        res = search_all(text)
-    else:
-        res = search_channel(channel_id, text)
-
-    if len(res) == 0:
-        show_message("no_matches_found")
-        exit()
-
-    for quote in res:
-        video_id = quote["video_id"]
-        subs = quote["text"]
-        time_stamp = quote["timestamp"]
-        video_title = get_title_from_db(video_id)
-        channel_name = get_channel_name_from_video_id(video_id)
-        time = time_to_secs(time_stamp) 
-
-        print("")
-        print(f"{channel_name}: \"{video_title}\"")
-        print(f"") 
-        print(f"    Quote: \"{subs.strip()}\"")
-        print(f"    Time Stamp: {time_stamp}")
-        print(f"    Link: https://youtu.be/{video_id}?t={time}\n")
 
 
 def export_search(channel_id, text, file_name):

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -7,7 +7,7 @@ from yt_fts.db_utils import *
 from yt_fts.download_utils import *
 from yt_fts.utils import *
 
-YT_FTS_VERSION = "0.1.12"
+YT_FTS_VERSION = "0.1.13"
 
 @click.group()
 @click.version_option(YT_FTS_VERSION, message='yt_fts version: %(version)s')


### PR DESCRIPTION
### Search by video flag
Users can now use `--video` to search for keywords within a video. The argument provided must be the
video id of the YouTube video.

syntax: 
```bash
yt-fts search "SEARCH_TEXT" --video [VIDEO_ID]
```

### new search syntax
modified search syntax to be more explicate about the scope of the search. User must use channel, all or video flags
to specify which scope they intend to search in. 

old:
```bash
yt-fts search "life in the big city" "The Tim Dillon Show"
# or 
yt-fts search "life in the big city" 1
```
new
```bash
yt-fts search "life in the big city" --channel "The Tim Dillon Show"
# or
yt-fts search "life in the big city" --channel 1
```

### Added video id to search output 
This will make it easier for users that want to use the video id in their next search

**Ex:**
```bash
yt-fts search "rea* kni* Mali*" --channel "The Tim Dillon Show" 
```
output:
```
The Tim Dillon Show: "#200 - Knife Fights In Malibu | The Tim Dillon Show - YouTube"

    Quote: "real knife fight down here in Malibu I"
    Time Stamp: 00:45:39.420
    Video ID: e79H5nxS65Q
    Link: https://youtu.be/e79H5nxS65Q?t=2736
```

### Module naming 
module naming convention changed to `[thing code does]_utils.py` 

### `search_utils` module 
moved search functions to `search_utils.py` 

### Misc 
- updated docs
- updated testing scripts
- bumped version number 
