### PR TITLE
Check the given channel URL against the expected pattern

### DIFF
--- a/yt_fts/utils.py
+++ b/yt_fts/utils.py
@@ -9,6 +9,7 @@ def show_message(code):
         "no_matches_found": "No matches found.\n- Try shortening the search text or use wildcards to match partial words.",
         "channel_not_found": "channel not found.\n- Try using channel id",
         "multiple_channels_found": "Multiple channels found.\n- Try using id",
+        "channel_url_not_correct": "The given channel URL is not correct, expected pattern : https://www.youtube.com/@TimDillonShow/videos",
     }
 
     print(error_dict[code])

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -51,6 +51,7 @@ def download(channel_url, channel_id, language, number_of_jobs):
     handle_reject_consent_cookie(channel_url, s)
 
     if channel_id is None:
+        check_channel_url_pattern(channel_url)
         channel_id = get_channel_id(channel_url, s)
     
     exists = check_if_channel_exists(channel_id)
@@ -301,6 +302,16 @@ commands = [list, download, update, search, semantic_search, export, delete, gen
 
 for command in commands:
     cli.add_command(command)
+
+
+def check_channel_url_pattern(channel_url):
+    """
+    Check the given channel URL against the expected pattern 
+    """
+    expected_url_format = "https:\/\/www.youtube.com\/@(.*)\/videos"
+    if not re.match(expected_url_format, channel_url):
+        show_message("channel_url_not_correct")
+        exit()
 
 
 def download_channel(channel_id, channel_name, language, number_of_jobs, s):


### PR DESCRIPTION
On channel homepage (ex.: https://www.youtube.com/@TimDillonShow), we can find more than one `channelId` match.

The user given channel URL needs to meet an expected pattern (ex.: https://www.youtube.com/@TimDillonShow/videos), on this specific page there is only one `channelId` occurence.

This a proposal to avoid #46.