### PR TITLE
Make config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ make_dist.sh
 *.sql
 tests.sh
 tests/*.txt
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # yt-fts - Youtube Full Text Search 
-`yt-fts` is a simple python script that uses yt-dlp to scrape all of a youtube channels subtitles
+`yt-fts` is a command line program that uses yt-dlp to scrape all of a youtube channels subtitles
 and load them into an sqlite database that is searchable from the command line. It allows you to
 query a channel for specific key word or phrase and will generate time stamped youtube urls to
 the video containing the keyword. 
@@ -58,7 +58,7 @@ Commands:
   list                Lists channels saved in the database.
   search              Search for a specified text within a channel, a...
   semantic-search     Semantic search for specified text.
-  show                Show transcripts for a video or list of videos...
+  show                Show video transcripts and video list for a...
   update              Updates a specified YouTube channel.
 ```
 
@@ -279,11 +279,13 @@ yt-fts delete 1
 ```
 Usage: yt-fts show [OPTIONS]
 
-  Show transcripts for a video or list of videos from a channel
+  Show video transcripts and video list for a specified channel or video. Also
+  shows the path to the config directory.
 
 Options:
   -v, --video TEXT    The video id to show transcripts for
   -c, --channel TEXT  The name or id of the channel to show video list
+  --config            Show path to config directory
 ```
 
 --- 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ entry_points = {
 
 setup(
     name='yt-fts', 
-    version='0.1.21',
+    version='0.1.22',
     description='yt-fts is a simple python script that uses yt-dlp to scrape all of a youtube channels subtitles and load them into an sqlite database that is searchable from the command line. It allows you to query a channel for specific key word or phrase and will generate time stamped youtube urls to the video containing the keyword.',
     long_description=long_description,
     long_description_content_type='text/markdown', 
@@ -24,5 +24,5 @@ setup(
     packages=find_packages(),
     install_requires=dependencies,
     entry_points=entry_points,
-    python_requires='>=3.11',
+    python_requires='>=3.8',
 )

--- a/yt_fts/config.py
+++ b/yt_fts/config.py
@@ -1,0 +1,73 @@
+import sys, os
+
+
+
+def get_config_path():
+
+    platform = sys.platform
+
+    if platform == 'win32':
+        config_path = os.path.join(os.getenv('APPDATA'), 'yt-fts')
+        if not os.path.exists(config_path):
+            return None
+        else:
+            return config_path 
+
+    if platform == 'darwin' or platform == 'linux':
+        config_path = os.path.join(os.getenv('HOME'), '.config', 'yt-fts')
+        if not os.path.exists(config_path):
+            return None
+        else:
+            return config_path
+    
+    return None
+
+
+def get_db_path():
+
+    platform = sys.platform
+
+    if platform == 'win32':
+        db_path = f"{os.path.join(os.getenv('APPDATA'), 'yt-fts')}/subtitles.db"
+        if not os.path.exists(db_path):
+            print("db path not found, using current directory")
+            return "subtitles.db" 
+        else:
+            return db_path 
+
+    if platform == 'darwin' or platform == 'linux':
+        db_path = f"{os.path.join(os.getenv('HOME'), '.config', 'yt-fts')}/subtitles.db"
+        if not os.path.exists(db_path):
+            print("db path not found, using current directory")
+            return "subtitles.db" 
+        else:
+            return db_path 
+    
+    print("db path not found, using current directory")
+    return "subtitles.db" 
+
+
+def make_config_dir():
+    platform = sys.platform
+
+    try:
+        if platform == 'win32':
+            config_path = os.path.join(os.getenv('APPDATA'), 'yt-fts')
+            # check if config dir exists
+            if not os.path.exists(config_path):
+                os.mkdir(config_path)
+                return config_path
+        
+        if platform == 'darwin' or platform == 'linux':
+            config_path = os.path.join(os.getenv('HOME'), '.config', 'yt-fts')
+            # check if config dir exists
+            if not os.path.exists(config_path):
+                os.mkdir(config_path)
+                return config_path
+    except Exception as e:
+        print(e)
+        return None
+
+
+
+

--- a/yt_fts/db_utils.py
+++ b/yt_fts/db_utils.py
@@ -175,7 +175,7 @@ def get_channel_name_from_video_id(video_id):
 # delete all videos, subtitles, and embeddings associated with channel
 def delete_channel(channel_id):
     
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(get_db_path())
     cur = conn.cursor()
 
     cur.execute("DELETE FROM Channels WHERE channel_id = ?", (channel_id,))

--- a/yt_fts/db_utils.py
+++ b/yt_fts/db_utils.py
@@ -4,11 +4,11 @@ from sqlite_utils import Database
 from tabulate import tabulate
 
 from yt_fts.utils import show_message
+from yt_fts.config import get_db_path 
 
-db_name = 'subtitles.db'
 
-def make_db():
-    db = Database(db_name)
+def make_db(db_path):
+    db = Database(db_path)
 
     db["Channels"].create({
             "channel_id": str,
@@ -92,7 +92,8 @@ def make_db():
 
 
 def add_channel_info(channel_id, channel_name, channel_url):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     db["Channels"].insert({
         "channel_id": channel_id,
@@ -102,7 +103,8 @@ def add_channel_info(channel_id, channel_name, channel_url):
 
 
 def add_video(channel_id, video_id,  video_title, video_url):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     db["Videos"].insert({
         "video_id": video_id,
@@ -113,7 +115,8 @@ def add_video(channel_id, video_id,  video_title, video_url):
 
 
 def add_subtitle(video_id, start_time, text):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     db["Subtitles"].insert({
         "video_id": video_id,
@@ -123,48 +126,56 @@ def add_subtitle(video_id, start_time, text):
 
 
 def get_channels():
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     return db.execute("SELECT ROWID, channel_id, channel_name, channel_url FROM Channels").fetchall()
 
 
 def search_channel(channel_id, text):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     return list(db["Subtitles"].search(text, where=f"video_id IN (SELECT video_id FROM Videos WHERE channel_id = '{channel_id}')"))
 
 
 def search_video(video_id, text):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     return list(db["Subtitles"].search(text, where=f"video_id = '{video_id}'"))
 
 def search_all(text):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     return list(db["Subtitles"].search(text))
 
 
 def get_title_from_db(video_id):
-    db = Database(db_name)
+
+    db = Database(get_db_path())
 
     return db.execute(f"SELECT video_title FROM Videos WHERE video_id = ?", [video_id]).fetchone()[0]
 
 
 def get_channel_name_from_id(channel_id):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     return db.execute(f"SELECT channel_name FROM Channels WHERE channel_id = ?", [channel_id]).fetchone()[0]
 
 def get_channel_name_from_video_id(video_id):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     return db.execute(f"SELECT channel_name FROM Channels WHERE channel_id = (SELECT channel_id FROM Videos WHERE video_id = ?)", [video_id]).fetchone()[0]
 
 
 # delete all videos, subtitles, and embeddings associated with channel
 def delete_channel(channel_id):
-    conn = sqlite3.connect(db_name)
+    
+    conn = sqlite3.connect(db_path)
     cur = conn.cursor()
 
     cur.execute("DELETE FROM Channels WHERE channel_id = ?", (channel_id,))
@@ -181,7 +192,8 @@ def delete_channel(channel_id):
 
 
 def get_channel_id_from_rowid(rowid):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     res = db.execute(f"SELECT channel_id FROM Channels WHERE ROWID = ?", [rowid]).fetchone()
 
@@ -192,7 +204,8 @@ def get_channel_id_from_rowid(rowid):
 
 
 def get_channel_id_from_name(channel_name):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     res = db.execute(f"SELECT channel_id FROM Channels WHERE channel_name = ?", [channel_name]).fetchall()
 
@@ -210,13 +223,15 @@ def get_channel_id_from_name(channel_name):
 
 # for listing specific channel 
 def get_channel_list_by_id(channel_id):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     return db.execute(f"SELECT ROWID, channel_name, channel_url FROM Channels WHERE channel_id = ?", [channel_id]).fetchall()
 
 
 def check_if_channel_exists(channel_id):
-    db=Database(db_name)
+
+    db = Database(get_db_path())
 
     res = db.execute(f"SELECT channel_id FROM Channels WHERE channel_id = ?", [channel_id]).fetchall()
     if len(res) > 0:
@@ -225,18 +240,21 @@ def check_if_channel_exists(channel_id):
         return False
 
 def get_num_vids(channel_id):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     return db.execute(f"SELECT COUNT(*) FROM Videos WHERE channel_id = ?", [channel_id]).fetchone()[0]
 
 def get_vid_ids_by_channel_id(channel_id):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     return db.execute(f"SELECT video_id FROM Videos WHERE channel_id = ?", [channel_id]).fetchall()
 
 
 def get_all_subs_by_channel_id(channel_id):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     parsed_subs = []
     subs = db.execute("""
@@ -253,7 +271,8 @@ def get_all_subs_by_channel_id(channel_id):
 
 # get all subs where semantic search is enabled
 def get_all_subs_by_channel_id_ss(channel_id):
-    db = Database(db_name)
+    
+    db = Database(get_db_path())
 
     parsed_subs = []
     subs = db.execute("""

--- a/yt_fts/download_utils.py
+++ b/yt_fts/download_utils.py
@@ -4,6 +4,7 @@ from progress.bar import Bar
 from concurrent.futures import ThreadPoolExecutor
 from bs4 import BeautifulSoup
 
+from yt_fts.config import get_db_path
 from yt_fts.db_utils import add_video
 from yt_fts.utils import parse_vtt
 
@@ -125,7 +126,7 @@ def vtt_to_db(channel_id, dir_path, s):
         if os.path.isfile(item_path):
             file_paths.append(item_path)    
 
-    con = sqlite3.connect('subtitles.db')  
+    con = sqlite3.connect(get_db_path())  
     cur = con.cursor()
 
     bar = Bar('Adding to database', max=len(file_paths))

--- a/yt_fts/list_utils.py
+++ b/yt_fts/list_utils.py
@@ -30,7 +30,10 @@ def list_channels(channel_id=None):
 
 #  not dry but for some reason importing from embeddings.py causes slow down 
 def check_ss_enabled(channel_id=None):
-    con = sqlite3.connect("subtitles.db")
+    from yt_fts.config import get_db_path
+
+    db_path = get_db_path() 
+    con = sqlite3.connect(db_path)
     cur = con.cursor()
 
     if channel_id is None:

--- a/yt_fts/semantic_serch/embeddings.py
+++ b/yt_fts/semantic_serch/embeddings.py
@@ -4,9 +4,10 @@ import pickle
 
 from progress.bar import Bar
 from tenacity import retry, wait_random_exponential, stop_after_attempt
+from yt_fts.config import get_db_path
 
 def get_openai_embeddings(subs, api_key):
-    conn = sqlite3.connect("subtitles.db")
+    conn = sqlite3.connect(get_db_path())
     cur = conn.cursor()
 
     bar = Bar('Generating embeddings', max=len(subs))
@@ -40,7 +41,7 @@ def get_embedding(api_key, text: str, model="text-embedding-ada-002") -> list[fl
 # should take a string for search_string and array of embeddings for search_embedding
 def save_search_embedding(search_string, search_embedding):
     search_embedding_blob = pickle.dumps(search_embedding)
-    con = sqlite3.connect("subtitles.db")
+    con = sqlite3.connect(get_db_path())
     cur = con.cursor()
 
     cur.execute(""" 
@@ -54,7 +55,7 @@ def save_search_embedding(search_string, search_embedding):
 # get embedding blob if exists 
 # should return an array of embeddings
 def search_semantic_search_hist(search_string):
-    con = sqlite3.connect("subtitles.db")
+    con = sqlite3.connect(get_db_path())
     cur = con.cursor()
 
     cur.execute(""" 
@@ -70,7 +71,7 @@ def search_semantic_search_hist(search_string):
 
 # check if semantic search has been enabled for channel
 def check_ss_enabled(channel_id=None):
-    con = sqlite3.connect("subtitles.db")
+    con = sqlite3.connect(get_db_path())
     cur = con.cursor()
 
     if channel_id is None:
@@ -91,7 +92,7 @@ def check_ss_enabled(channel_id=None):
 
 # enable semantic search for channel
 def enable_ss(channel_id):
-    con = sqlite3.connect("subtitles.db")
+    con = sqlite3.connect(get_db_path())
     cur = con.cursor()
 
     cur.execute(""" 

--- a/yt_fts/semantic_serch/search_embeddings.py
+++ b/yt_fts/semantic_serch/search_embeddings.py
@@ -11,9 +11,10 @@ from yt_fts.utils import time_to_secs
 from yt_fts.search_utils import get_channel_name_from_video_id
 from yt_fts.db_utils import get_title_from_db
 from yt_fts.search_utils import print_search_results
+from yt_fts.config import get_db_path
 
 def search_using_embedding(search_embedding, top_n, channel_id=None):
-    con = sqlite3.connect('subtitles.db')
+    con = sqlite3.connect(get_db_path())
     cur = con.cursor()
     if channel_id is None:
         cur.execute("SELECT * FROM Embeddings")

--- a/yt_fts/show.py
+++ b/yt_fts/show.py
@@ -7,8 +7,10 @@ from rich.table import Table
 from yt_fts.db_utils import get_title_from_db 
 from yt_fts.utils import time_to_secs, get_time_delta
 
+from yt_fts.config import get_db_path
+
 def show_video_transcript(video_id):
-    con = sqlite3.connect('subtitles.db')
+    con = sqlite3.connect(get_db_path())
     cur = con.cursor()
     cur.execute("SELECT * FROM subtitles WHERE video_id=?", (video_id,))
     rows = cur.fetchall()
@@ -38,7 +40,7 @@ def show_video_transcript(video_id):
 
 
 def show_video_list(channel_id):
-    con = sqlite3.connect('subtitles.db')
+    con = sqlite3.connect(get_db_path())
     cur = con.cursor()
     cur.execute("SELECT * FROM videos WHERE channel_id=?", (channel_id,))
 

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -6,6 +6,7 @@ from yt_fts.download_utils import *
 from yt_fts.utils import *
 from yt_fts.update_utils import update_channel
 from yt_fts.list_utils import list_channels
+from yt_fts.config import get_config_path, make_config_dir, get_db_path
 
 
 YT_FTS_VERSION = "0.1.21"
@@ -13,7 +14,24 @@ YT_FTS_VERSION = "0.1.21"
 @click.group()
 @click.version_option(YT_FTS_VERSION, message='yt_fts version: %(version)s')
 def cli():
-    make_db()
+
+    config_path = get_config_path()
+    if config_path is None:
+        new_config_path = make_config_dir()
+        if new_config_path is None:
+            print("Error: Could not create config directory, database will be saved in current directory")
+            make_db("subtitles.db")
+        else:
+            new_db_path = os.path.join(new_config_path, "subtitles.db") 
+            make_db(new_db_path)
+            print(f"Database saved to: {new_db_path}")
+    else:
+        db_path = get_db_path()
+        make_db(db_path)
+
+    db_path = get_db_path()
+    make_db(db_path)
+
 
 
 # list
@@ -299,9 +317,15 @@ def generate_embeddings(channel, open_api_key):
 )
 @click.option("-v", "--video", default=None, help="The video id to show transcripts for")
 @click.option("-c","--channel", default=None, help="The name or id of the channel to show video list")
-def show(video, channel):
+@click.option("--config", is_flag=True, help="Show path to config directory")
+def show(video, channel, config):
 
     from yt_fts.show import show_video_transcript, show_video_list
+
+    if config:
+        config_path = get_config_path()
+        print(f"Config path: {config_path}")
+        exit()
 
     if video:
         show_video_transcript(video)

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -9,7 +9,7 @@ from yt_fts.list_utils import list_channels
 from yt_fts.config import get_config_path, make_config_dir, get_db_path
 
 
-YT_FTS_VERSION = "0.1.21"
+YT_FTS_VERSION = "0.1.22"
 
 @click.group()
 @click.version_option(YT_FTS_VERSION, message='yt_fts version: %(version)s')
@@ -24,7 +24,7 @@ def cli():
         else:
             new_db_path = os.path.join(new_config_path, "subtitles.db") 
             make_db(new_db_path)
-            print(f"Database saved to: {new_db_path}")
+            print(f"Your subtitles database has been saved to: {new_db_path}")
     else:
         db_path = get_db_path()
         make_db(db_path)
@@ -312,7 +312,8 @@ def generate_embeddings(channel, open_api_key):
 # Show video transcripts and video list 
 @click.command( 
     help="""
-    Show transcripts for a video or list of videos from a channel
+    Show video transcripts and video list for a specified channel or video.
+    Also shows the path to the config directory.
     """
 )
 @click.option("-v", "--video", default=None, help="The video id to show transcripts for")


### PR DESCRIPTION
-Subtitles database now saved to platform specific config directory 
    - macos and linux: `~/.config/yt-fts`
    - windows `APPDATA\yt-fts`
-Replaced hard coded db paths with `get_db_path()` function. 
- If it fails to find a database in the config path it just returns "subtitles.db.
-Tested on macos and a couple linux distros. still need to test on windows. 
- Lowered required python version to `3.8` 
- Added `--conifg` to the show command to show the user where their database is located

