### PR TITLE
Fixed bootstrapping config dir and directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ tests/rich_tests
 
 .vscode
 tests/rich_tests
+
+DEVLOG.md

--- a/yt_fts/config.py
+++ b/yt_fts/config.py
@@ -24,22 +24,42 @@ def get_config_path():
 
 
 def get_db_path():
+    from .db_utils import make_db
+    # make sure config path exists
+    # if config path is none, make config path
+    # this also means the db doesn't exist
+    # make db in new config path
+
+    config_path = get_config_path()
+    if config_path is None:
+
+        config_path = make_config_dir()
+
+        # if config path is still none, that means we can't make a config path
+        # use current directory
+        if config_path is None:
+            print("unable to make config path, using current directory")
+            return "subtitles.db"
+        
 
     platform = sys.platform
 
     if platform == 'win32':
-        db_path = f"{os.path.join(os.getenv('APPDATA'), 'yt-fts')}/subtitles.db"
+        db_path = f"{config_path}/subtitles.db"
+
         if not os.path.exists(db_path):
-            print("db path not found, using current directory")
-            return "subtitles.db" 
+            print("db path not found, making new db")
+            make_db(db_path)
+            return db_path
         else:
             return db_path 
 
     if platform == 'darwin' or platform == 'linux':
-        db_path = f"{os.path.join(os.getenv('HOME'), '.config', 'yt-fts')}/subtitles.db"
+        db_path = f"{config_path}/subtitles.db"
         if not os.path.exists(db_path):
-            print("db path not found, using current directory")
-            return "subtitles.db" 
+            print("db path not found, making new db")
+            make_db(db_path)
+            return db_path 
         else:
             return db_path 
     

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -10,29 +10,13 @@ from .update import update_channel
 from .utils import *
 from rich.console import Console
 
-YT_FTS_VERSION = "0.1.32"
+YT_FTS_VERSION = "0.1.33"
 
 @click.group()
 @click.version_option(YT_FTS_VERSION, message='yt_fts version: %(version)s')
 def cli():
-
     config_path = get_config_path()
-    if config_path is None:
-        new_config_path = make_config_dir()
-        if new_config_path is None:
-            print("Error: Could not create config directory, database will be saved in current directory")
-            make_db("subtitles.db")
-        else:
-            new_db_path = os.path.join(new_config_path, "subtitles.db") 
-            make_db(new_db_path)
-            print(f"Your subtitles database has been saved to: {new_db_path}")
-    else:
-        db_path = get_db_path()
-        make_db(db_path)
-
     db_path = get_db_path()
-    make_db(db_path)
-
 
 
 # download
@@ -296,6 +280,9 @@ def get_embeddings(channel, api_key):
     """
 )
 def config():
+    config_path = get_config_path()
+    db_path = get_db_path()
     console = Console()
     config_path = get_config_path()
     console.print(f"\nConfig directory: {config_path}\n")
+    console.print(f"Database path: {db_path}\n")


### PR DESCRIPTION
The subtitle database was always being set to current directory. I'm not sure when this was introduced.

- `get_db_path()` now creates a configuration directory by default and will still make a subtitles db in current directory if something fails
- the `config` command now prints full database path
- removed whatever was happening in `cli`, was originally supposed to be a bootstrapping thing but it doesn't work and was a bad idea to begin with.  