### PR TITLE
Support Live Streamed Videos

### DIFF
--- a/yt_fts/download.py
+++ b/yt_fts/download.py
@@ -92,6 +92,23 @@ def get_videos_list(channel_url):
         res = subprocess.run(cmd, capture_output=True, check=True)
         list_of_videos_urls = res.stdout.decode().splitlines()
 
+        streams_url = channel_url.replace("/videos", "/streams") 
+        cmd = [
+            "yt-dlp",
+            "--flat-playlist",
+            "--print",
+            "id",
+            streams_url
+        ]
+        res = subprocess.run(cmd, capture_output=True, check=True)
+
+        live_stream_urls = res.stdout.decode().splitlines()
+
+
+        if len(live_stream_urls) > 0:
+            list_of_videos_urls.extend(live_stream_urls)
+
+
     return list_of_videos_urls 
 
 


### PR DESCRIPTION
Downloading streams is the same process as downloading videos. 
The problem was that our function to get all of a channels videos doesn't
get all videos under `/streams` so I just added another sub process call to 
yt-dlp using the same flags but with `/streams` instead of `/videos` 