### PR TITLE
Implement Error Handling for Missing Streams Tab in yt-dlp Calls

### DIFF
--- a/yt_fts/download.py
+++ b/yt_fts/download.py
@@ -100,13 +100,13 @@ def get_videos_list(channel_url):
             "id",
             streams_url
         ]
-        res = subprocess.run(cmd, capture_output=True, check=True)
-
-        live_stream_urls = res.stdout.decode().splitlines()
-
-
-        if len(live_stream_urls) > 0:
-            list_of_videos_urls.extend(live_stream_urls)
+        try:
+            res = subprocess.run(cmd, capture_output=True, check=True)
+            live_stream_urls = res.stdout.decode().splitlines()
+            if len(live_stream_urls) > 0:
+                list_of_videos_urls.extend(live_stream_urls)
+        except subprocess.CalledProcessError:
+            console.print("[bold red]No streams tab found or error fetching streams.")
 
 
     return list_of_videos_urls 


### PR DESCRIPTION
Hello!

I've been working with your tool and ran into an issue that I wanted to address. Though this is a tiny contribution, so I'm excited to propose this fix!

**Issue Encountered:**
While fetching video ids using `yt-dlp` for channels without a streams tab (as in my sample channel here), the script crashes with the following error:

```
subprocess.CalledProcessError: Command '['yt-dlp', '--flat-playlist', '--print', 'id', 'https://www.youtube.com/channel/UCwpMRCoVgSJ-rKyV1yhWljg/streams']' returned non-zero exit status 1.
```

And `yt-dlp` outputs:

```
ERROR: [youtube:tab] UCwpMRCoVgSJ-rKyV1yhWljg: This channel does not have a streams tab
```

**Proposed Solution:**
I've added a try-except block to the `get_videos_list`  function in `download.py` to handle this gracefully. The script now continues to run and returns any video URLs it can fetch, even if the streams tab is missing.

Here's the key change in the code:

```python3
try:
    res = subprocess.run(cmd, capture_output=True, check=True)
    live_stream_urls = res.stdout.decode().splitlines()
    if len(live_stream_urls) > 0:
        list_of_videos_urls.extend(live_stream_urls)
except subprocess.CalledProcessError:
    console.print("[bold red]No streams tab found or error fetching streams.")
```

**Testing:**
Tested this with various channels, and it's working well. Looking forward to your feedback!

Cheers!
🍒