### PR TITLE
fixed issue with incorrect end time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,4 +172,4 @@ examples
 UCYO_jab_esuFRV4b17AJtAw
 .ignore
 .ignore/
-.ignore/*
+tests/test_data/

--- a/tests/test_parse_vtt.py
+++ b/tests/test_parse_vtt.py
@@ -1,0 +1,24 @@
+import unittest
+import os
+import shutil
+
+from pprint import pprint
+from yt_fts.utils import parse_vtt
+
+class TestParseVtt(unittest.TestCase):
+    def test_parse_vtt(self):
+
+        source = "tests/test_data/vtt/test.vtt"
+        dest = "tests/test.vtt"
+
+        shutil.copy2(source, dest)
+        temp_path = "tests/test.vtt"
+
+        result = parse_vtt(temp_path)
+
+        pprint(result)
+
+        os.remove(temp_path)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/yt_fts/utils.py
+++ b/yt_fts/utils.py
@@ -54,7 +54,12 @@ def parse_vtt(file_path):
 
             # prevent duplicate entries
             if result and result[-1]['text'] == sub_titles.strip('\n'):
-                continue
+                # replace the previous entry with the new one
+                result[-1] = {
+                    'start_time': start_time,
+                    'stop_time': stop_time,
+                    'text': sub_titles.strip('\n'),
+                }
             else:   
                 result.append({
                     'start_time': start_time,

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -9,7 +9,7 @@ from .update import update_channel
 from .utils import *
 from rich.console import Console
 
-YT_FTS_VERSION = "0.1.39"
+YT_FTS_VERSION = "0.1.40"
 
 @click.group()
 @click.version_option(YT_FTS_VERSION, message='yt_fts version: %(version)s')


### PR DESCRIPTION
instead of skipping iteration when encountering a duplicate simply replace
the previous entry with the current entry

```python
      if result and result[-1]['text'] == sub_titles.strip('\n'):
                # replace the previous entry with the new one
                result[-1] = {
                    'start_time': start_time,
                    'stop_time': stop_time,
                    'text': sub_titles.strip('\n'),
                }           
```

