### PR TITLE
Db lock error on delete

### DIFF
--- a/yt_fts/db_utils.py
+++ b/yt_fts/db_utils.py
@@ -158,6 +158,9 @@ def delete_channel(channel_id):
     from .utils import check_ss_enabled
     from .vector_search import delete_channel_from_chroma 
 
+    if check_ss_enabled(channel_id):
+        delete_channel_from_chroma(channel_id)
+
     conn = sqlite3.connect(get_db_path())
     cur = conn.cursor()
 
@@ -167,9 +170,6 @@ def delete_channel(channel_id):
     cur.execute("DELETE FROM Subtitles WHERE video_id IN (SELECT video_id FROM Videos WHERE channel_id = ?)", (channel_id,))
 
     cur.execute("DELETE FROM Videos WHERE channel_id = ?", (channel_id,))
-
-    if check_ss_enabled(channel_id):
-        delete_channel_from_chroma(channel_id)
 
     cur.execute("DELETE FROM SemanticSearchEnabled WHERE channel_id = ?", (channel_id,))
 


### PR DESCRIPTION
The delete function checks calls `check_ss_enabled` after opening 
an sqlite connection, `check_ss_enabled` also opens a connection. 
```python
    conn = sqlite3.connect(get_db_path())
    cur = conn.cursor()
   ...
  if check_ss_enabled(channel_id):
      delete_channel_from_chroma(channel_id)
      
```
Concurrent reading should be okay with sqlite and this was fine when
I was testing it, but now I'm getting database lock errors. Quick fix is just 
to move the call to `check_ss_enabled` to before opening the other connection