### PR TITLE
Allow specifying -h for help

### DIFF
--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -11,7 +11,7 @@ from rich.console import Console
 
 YT_FTS_VERSION = "0.1.41"
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(YT_FTS_VERSION, message='yt_fts version: %(version)s')
 def cli():
     config_path = get_config_path()


### PR DESCRIPTION
Muscle memory demands `-h` :sweat_smile: 

Would you consider an additional commit enabling `no_args_is_help` from https://click.palletsprojects.com/en/8.1.x/api/#click.Command?