### PR TITLE
Hotfix for unicode decode error #138 

### DIFF
--- a/yt_fts/download.py
+++ b/yt_fts/download.py
@@ -211,7 +211,7 @@ def vtt_to_db(dir_path):
 
         vid_json_path = os.path.join(os.path.dirname(vtt), f'{vid_id}.info.json')
 
-        with open(vid_json_path, "r") as f:
+        with open(vid_json_path, 'r', encoding='utf-8', errors='ignore') as f:
             vid_json = json.load(f)
 
         vid_title =  vid_json['title']


### PR DESCRIPTION
Original issue was with `get_vid_title()` function but it was removed in 58b538b so we could just read the JSON from the calling function. I have not been able to reproduce this, could be isolated to windows systems. Either way specifying UTF-8 encoding shouldn't break anything. 