### PR TITLE
Fix download format errors, bump yt-dlp version, set default jobs to 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "rich==13.7.1",
     "sqlite-utils==3.36",
     "beautifulsoup4==4.12.3",
-    "yt-dlp==2024.7.16",
+    "yt-dlp==2025.6.30",
     "webvtt-py==0.5.1",
 ]
 

--- a/yt_fts/yt_fts.py
+++ b/yt_fts/yt_fts.py
@@ -46,7 +46,7 @@ def cli():
               help="Download all videos from a playlist")
 @click.option("-l", "--language", default="en",
               help="Language of the subtitles to download")
-@click.option("-j", "--jobs", type=int, default=1,
+@click.option("-j", "--jobs", type=int, default=8,
               help="Optional number of jobs to parallelize the run")
 @click.option("--cookies-from-browser", default=None,
               help="Browser to extract cookies from. Ex: chrome, firefox")


### PR DESCRIPTION
This pull request introduces changes to improve the functionality and usability of the YouTube channel downloader. Key updates include modifying the behavior for handling duplicate channels, increasing the default number of parallel jobs, fixing a typo in a variable name, and adding a new test case for channel updates. These changes enhance user experience and improve code reliability.

### Enhancements to duplicate channel handling:
* [`yt_fts/download.py`](diffhunk://#diff-e33c32d6d9355bccfa49d5b2317425da129b78039e78d52811f43726836fcfbbL55-R57): Updated the `download_channel` method to allow updating existing channels instead of exiting with an error. Removed the `handle_channel_exists` method, which previously handled duplicates by displaying an error message. [[1]](diffhunk://#diff-e33c32d6d9355bccfa49d5b2317425da129b78039e78d52811f43726836fcfbbL55-R57) [[2]](diffhunk://#diff-e33c32d6d9355bccfa49d5b2317425da129b78039e78d52811f43726836fcfbbL350-R357)
* [`yt_fts/download.py`](diffhunk://#diff-e33c32d6d9355bccfa49d5b2317425da129b78039e78d52811f43726836fcfbbR101-R107): Modified the `update_channel` method to handle both `channel_id` and alternative identifiers (e.g., `rowid` or `channel name`) for updating channels.

### Default parallelization improvement:
* [`yt_fts/download.py`](diffhunk://#diff-e33c32d6d9355bccfa49d5b2317425da129b78039e78d52811f43726836fcfbbL25-R33): Increased the default number of jobs for parallel downloads from 1 to 8 in the `DownloadHandler` class.
* [`yt_fts/yt_fts.py`](diffhunk://#diff-054974b9aa379a67d371a56f7aa6897da65bb09fab977164aab2be4bb22a7514L49-R49): Updated the `--jobs` CLI option to default to 8 parallel jobs.

### Bug fix:
* [`yt_fts/download.py`](diffhunk://#diff-e33c32d6d9355bccfa49d5b2317425da129b78039e78d52811f43726836fcfbbL42-R42): Fixed a typo in the variable name `self.channl_id`, correcting it to `self.channel_id`.

### New test case:
* [`tests/test_download.py`](diffhunk://#diff-b918cfaffb9f8f78fe453482131da561f565b9aaf98b4df54989a1c04ccb452aR124-R168): Added a test case, `test_channel_update_on_duplicate`, to verify that downloading a duplicate channel updates its data instead of failing. This ensures the new behavior is properly tested.

### Dependency update:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L30-R30): Updated the `yt-dlp` dependency from version `2024.7.16` to `2025.6.30` to ensure compatibility and access to the latest features.